### PR TITLE
Fix HTTPHeaderDict bytes key handling

### DIFF
--- a/src/urllib3/_collections.py
+++ b/src/urllib3/_collections.py
@@ -259,6 +259,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
         return ", ".join(val[1:])
 
     def __delitem__(self, key: str) -> None:
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         del self._container[key.lower()]
 
     def __contains__(self, key: object) -> bool:
@@ -376,6 +378,8 @@ class HTTPHeaderDict(typing.MutableMapping[str, str]):
     ) -> list[str] | _DT:
         """Returns a list of all the values for the named field. Returns an
         empty list if the key doesn't exist."""
+        if isinstance(key, bytes):
+            key = key.decode("latin-1")
         try:
             vals = self._container[key.lower()]
         except KeyError:

--- a/test/test_collections.py
+++ b/test/test_collections.py
@@ -230,6 +230,10 @@ class TestHTTPHeaderDict:
         assert "cookie" not in d
         assert "COOKIE" not in d
 
+    def test_delitem_with_bytes_key(self, d: HTTPHeaderDict) -> None:
+        del d[b"cookie"]
+        assert "cookie" not in d
+
     def test_add_well_known_multiheader(self, d: HTTPHeaderDict) -> None:
         d.add("COOKIE", "asdf")
         assert d.getlist("cookie") == ["foo", "bar", "asdf"]
@@ -317,6 +321,9 @@ class TestHTTPHeaderDict:
         assert d.getlist("b") == []
         d.add("b", "asdf")
         assert d.getlist("b") == ["asdf"]
+
+    def test_getlist_with_bytes_key(self, d: HTTPHeaderDict) -> None:
+        assert d.getlist(b"cookie") == ["foo", "bar"]
 
     def test_getlist_after_copy(self, d: HTTPHeaderDict) -> None:
         assert d.getlist("cookie") == HTTPHeaderDict(d).getlist("cookie")


### PR DESCRIPTION
## Summary
- handle bytes keys in HTTPHeaderDict.__delitem__ and getlist
- test bytes key handling in HTTPHeaderDict

## Testing
- `PYTHONPATH=src python -m pytest test/test_collections.py -q`